### PR TITLE
fix for bind9

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -150,7 +150,7 @@ services:
         ipv4_address: 172.16.254.10
 
   bind:
-    image: internetsystemsconsortium/bind9:9.16
+    image: internetsystemsconsortium/bind9:9.20
     container_name: bind
     ports:
       - "53:53/udp"


### PR DESCRIPTION
the docker-compose file requests bind9 version 9.16 which is no longer available as per: https://hub.docker.com/r/internetsystemsconsortium/bind9/tags